### PR TITLE
Draw from kd tree

### DIFF
--- a/src/main/java/com/noticemedan/map/view/MainViewController.java
+++ b/src/main/java/com/noticemedan/map/view/MainViewController.java
@@ -44,9 +44,8 @@ public class MainViewController {
 	private void insertMapCanvasIntoPane() {
 		CustomPane mapCanvas = new CustomPane(new Dimension(1600, 1600));
 		MouseController controller = new MouseController();
-		controller.addZoomAbility(mapCanvas);
-		controller.panning(mapCanvas);
-		controller.panDraw(mapCanvas);
+		//controller.addZoomAbility(mapCanvas);
+		controller.dragAndDraw(mapCanvas);
 		mapPaneContainer.getChildren().addAll(mapCanvas);
 	}
 

--- a/src/main/java/com/noticemedan/map/view/MainViewController.java
+++ b/src/main/java/com/noticemedan/map/view/MainViewController.java
@@ -44,7 +44,7 @@ public class MainViewController {
 	private void insertMapCanvasIntoPane() {
 		CustomPane mapCanvas = new CustomPane(new Dimension(1600, 1600));
 		MouseController controller = new MouseController();
-		//controller.addZoomAbility(mapCanvas);
+		controller.addZoomAbility(mapCanvas);
 		controller.dragAndDraw(mapCanvas);
 		mapPaneContainer.getChildren().addAll(mapCanvas);
 	}

--- a/src/main/java/com/noticemedan/map/view/MainViewController.java
+++ b/src/main/java/com/noticemedan/map/view/MainViewController.java
@@ -45,6 +45,8 @@ public class MainViewController {
 		CustomPane mapCanvas = new CustomPane(new Dimension(1600, 1600));
 		MouseController controller = new MouseController();
 		controller.addZoomAbility(mapCanvas);
+		controller.panning(mapCanvas);
+		controller.panDraw(mapCanvas);
 		mapPaneContainer.getChildren().addAll(mapCanvas);
 	}
 

--- a/src/main/java/com/noticemedan/map/viewmodel/CustomPane.java
+++ b/src/main/java/com/noticemedan/map/viewmodel/CustomPane.java
@@ -11,19 +11,19 @@ import java.awt.*;
 public class CustomPane extends ScrollPane {
     private Group paneViewContent;
     @Getter private Group canvasContent;
-    private MapCanvas mapCanvas;
+    @Getter private MapCanvas mapCanvas;
 
     public CustomPane(Dimension dim) {
         super();
-        initializeFields(dim);
+        initializeFields();
         applyContent();
-        adjustPaneProperties(dim);
+        adjustPaneProperties();
         setWidth(dim.getWidth());
         setHeight(dim.getHeight());
     }
 
-    private void initializeFields(Dimension dim){
-        this.mapCanvas = new MapCanvas(dim);
+    private void initializeFields(){
+        this.mapCanvas = new MapCanvas();
         this.paneViewContent = new Group();
         this.canvasContent = new Group();
     }
@@ -34,12 +34,12 @@ public class CustomPane extends ScrollPane {
         this.setContent(paneViewContent);
     }
 
-    private void adjustPaneProperties(Dimension dim){
+    private void adjustPaneProperties(){
     	this.setStyle("-fx-background: #2349B5");
 		this.setPrefWidth(1100);
 		this.setPrefHeight(650);
-        this.setHbarPolicy(ScrollBarPolicy.NEVER);
-        this.setVbarPolicy(ScrollBarPolicy.NEVER);
+        //this.setHbarPolicy(ScrollBarPolicy.NEVER);
+        //this.setVbarPolicy(ScrollBarPolicy.NEVER);
         this.setPannable(true);
     }
 

--- a/src/main/java/com/noticemedan/map/viewmodel/CustomPane.java
+++ b/src/main/java/com/noticemedan/map/viewmodel/CustomPane.java
@@ -1,9 +1,7 @@
 package com.noticemedan.map.viewmodel;
 
 import com.noticemedan.map.model.KDTree.Rect;
-import javafx.geometry.Point2D;
 import javafx.scene.Group;
-import javafx.scene.canvas.Canvas;
 import javafx.scene.control.ScrollPane;
 import lombok.Getter;
 
@@ -23,7 +21,7 @@ public class CustomPane extends ScrollPane {
         setHeight(dim.getHeight());
     }
 
-    private void initializeFields(){
+    private void initializeFields() {
         this.mapCanvas = new MapCanvas();
         this.paneViewContent = new Group();
         this.canvasContent = new Group();
@@ -35,7 +33,7 @@ public class CustomPane extends ScrollPane {
         this.setContent(paneViewContent);
     }
 
-    private void adjustPaneProperties(){
+    private void adjustPaneProperties() {
     	this.setStyle("-fx-background: #2349B5");
 		this.setPrefWidth(1100);
 		this.setPrefHeight(650);
@@ -44,10 +42,9 @@ public class CustomPane extends ScrollPane {
         this.setPannable(true);
     }
 
-    public Rect getExtendedViewPortBounds(){
+    public Rect getExtendedViewPortBounds() {
 		double minX = Math.abs(this.getViewportBounds().getMinX());
 		double minY = Math.abs(this.getViewportBounds().getMinY());
-
 		double maxX = minX + this.getViewportBounds().getWidth();
 		double maxY = minY + this.getViewportBounds().getHeight();
 

--- a/src/main/java/com/noticemedan/map/viewmodel/CustomPane.java
+++ b/src/main/java/com/noticemedan/map/viewmodel/CustomPane.java
@@ -1,5 +1,6 @@
 package com.noticemedan.map.viewmodel;
 
+import com.noticemedan.map.model.KDTree.Rect;
 import javafx.geometry.Point2D;
 import javafx.scene.Group;
 import javafx.scene.canvas.Canvas;
@@ -43,66 +44,13 @@ public class CustomPane extends ScrollPane {
         this.setPannable(true);
     }
 
-    public void repositionScroller(double scaleFactor, Point2D scrollOffset) {
-        adjustHorizontalPosition(scaleFactor,scrollOffset.getX());
-        adjustVerticalPosition(scaleFactor,scrollOffset.getY());
-    }
+    public Rect getExtendedViewPortBounds(){
+		double minX = Math.abs(this.getViewportBounds().getMinX());
+		double minY = Math.abs(this.getViewportBounds().getMinY());
 
-    private void adjustHorizontalPosition(double scaleFactor, double offSet){
-        double deltaWidth = this.paneViewContent.getLayoutBounds().getWidth() - this.getViewportBounds().getWidth();
-        if (deltaWidth > 0) {
-            double horizontalCenter = this.getViewportBounds().getWidth() / 2 ;
-            double newScrollXOffset = (scaleFactor - 1) *  horizontalCenter + scaleFactor * offSet;
-            this.setHvalue(this.getHmin() + newScrollXOffset * (this.getHmax() - this.getHmin()) / deltaWidth);
-        } else {
-            this.setHvalue(this.getHmin());
-        }
-    }
+		double maxX = minX + this.getViewportBounds().getWidth();
+		double maxY = minY + this.getViewportBounds().getHeight();
 
-    private void adjustVerticalPosition(double scaleFactor, double offSet){
-        double deltaHeight = this.paneViewContent.getLayoutBounds().getHeight() - this.getViewportBounds().getHeight();
-        if (deltaHeight > 0) {
-            double halfHeight = this.getViewportBounds().getHeight() / 2 ;
-            double newScrollYOffset = (scaleFactor - 1) * halfHeight + scaleFactor * offSet;
-            this.setVvalue(this.getVmin() + newScrollYOffset * (this.getVmax() - this.getVmin()) / deltaHeight);
-        } else {
-            this.setVvalue(this.getVmin());
-        }
-    }
-
-    public Point2D calculateScrollOffset() {
-        double XOffset = calculateHorizontalOffset();
-        double YOffset = calculateVerticalOffset();
-        return new Point2D(XOffset, YOffset);
-    }
-
-    private double calculateHorizontalOffset(){
-        double contentWidth = this.paneViewContent.getLayoutBounds().getWidth();
-        double viewportWidth = this.getViewportBounds().getWidth();
-        double deltaWidth = contentWidth - viewportWidth;
-        double horizontalScrollProportion = (this.getHvalue() - this.getHmin()) / (this.getHmax() - this.getHmin());
-
-        return horizontalScrollProportion * Math.max(0, deltaWidth);
-    }
-
-    private double calculateVerticalOffset(){
-        double contentHeight = this.paneViewContent.getLayoutBounds().getHeight();
-        double viewportHeight = this.getViewportBounds().getHeight();
-        double deltaHeight = contentHeight - viewportHeight;
-        double verticalScrollProportion = (this.getVvalue() - this.getVmin()) / (this.getVmax() - this.getVmin());
-
-        return verticalScrollProportion * Math.max(0, deltaHeight);
-    }
-
-    public void zoomToCenter(double scaleFactor){
-        // amount of scrolling in each direction in paneViewContent coordinate units
-        Point2D scrollOffset = this.calculateScrollOffset();
-        Canvas canvas = mapCanvas.getCanvas();
-
-        canvas.setScaleX(canvas.getScaleX() * scaleFactor);
-        canvas.setScaleY(canvas.getScaleY() * scaleFactor);
-
-        // move viewport so that old center remains in the center after the scaling
-        this.repositionScroller(scaleFactor, scrollOffset);
-    }
+		return new Rect(minX * 0.5 ,minY * 0.5,maxX * 1.5,maxY * 1.5);
+	}
 }

--- a/src/main/java/com/noticemedan/map/viewmodel/CustomPane.java
+++ b/src/main/java/com/noticemedan/map/viewmodel/CustomPane.java
@@ -42,12 +42,12 @@ public class CustomPane extends ScrollPane {
         this.setPannable(true);
     }
 
-    public Rect getExtendedViewPortBounds() {
+    public Rect getExtendedViewPortBounds(double zoomLevel) {
 		double minX = Math.abs(this.getViewportBounds().getMinX());
 		double minY = Math.abs(this.getViewportBounds().getMinY());
 		double maxX = minX + this.getViewportBounds().getWidth();
 		double maxY = minY + this.getViewportBounds().getHeight();
-
-		return new Rect(minX * 0.5 ,minY * 0.5,maxX * 1.5,maxY * 1.5);
+		double extendvalue = 1/zoomLevel;
+		return new Rect(minX * 0.5 * extendvalue,minY * 0.5 * extendvalue,maxX * 1.5 * extendvalue,maxY * 1.5 * extendvalue);
 	}
 }

--- a/src/main/java/com/noticemedan/map/viewmodel/MapCanvas.java
+++ b/src/main/java/com/noticemedan/map/viewmodel/MapCanvas.java
@@ -1,11 +1,9 @@
 package com.noticemedan.map.viewmodel;
 
-
 import com.noticemedan.map.model.KDTree.Forest;
 import com.noticemedan.map.model.KDTree.ForestCreator;
 import com.noticemedan.map.model.KDTree.Rect;
 import com.noticemedan.map.model.MapObject;
-import com.noticemedan.map.model.MapObjectCreater;
 import com.noticemedan.map.model.OSMType;
 import javafx.geometry.Point2D;
 import javafx.scene.canvas.Canvas;
@@ -14,10 +12,7 @@ import javafx.scene.paint.Color;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
-
-import java.awt.*;
 import java.util.List;
-import java.util.Map;
 
 @Slf4j
 public class MapCanvas {
@@ -48,13 +43,13 @@ public class MapCanvas {
 		drawObjects(forest.rangeSearch(viewArea));
 	}
 
-	public void redrawCanvas(){
+	public void redrawCanvas() {
 		pen.clearRect(0,0,canvas.getWidth(),canvas.getHeight());
 		drawCanvas();
 	}
 
-	private void drawObjects(List<MapObject> objects){
-		for(MapObject object : objects){
+	private void drawObjects(List<MapObject> objects) {
+		for(MapObject object : objects) {
 			if(object.getOsmType()==OSMType.UNKNOWN) continue;
 			if(object.getColor()!=null) setPenColor(object.getColor()); //IF-STATEMENT UNTIL MapObject getColor() WORKS PROPERLY
 
@@ -76,7 +71,7 @@ public class MapCanvas {
 		}
 	}
 
-	private void setPenColor(Color color){
+	private void setPenColor(Color color) {
 		pen.setStroke(color);
 		pen.setFill(color);
 	}

--- a/src/main/java/com/noticemedan/map/viewmodel/MapCanvas.java
+++ b/src/main/java/com/noticemedan/map/viewmodel/MapCanvas.java
@@ -48,13 +48,13 @@ public class MapCanvas {
 		drawCanvas();
 	}
 
-	private void drawObjects(List<MapObject> objects) {
-		for(MapObject object : objects) {
-			if(object.getOsmType()==OSMType.UNKNOWN) continue;
-			if(object.getColor()!=null) setPenColor(object.getColor()); //IF-STATEMENT UNTIL MapObject getColor() WORKS PROPERLY
+	private void drawObjects(List<MapObject> mapObjects) {
+		for(MapObject mapObject : mapObjects) {
+			if(mapObject.getOsmType()==OSMType.UNKNOWN) continue;
+			if(mapObject.getColor()!=null) setPenColor(mapObject.getColor()); //IF-STATEMENT UNTIL MapObject getColor() WORKS PROPERLY
 
-			drawPath(object.getPoints());
-			if ((isClosed(object))) {
+			drawPath(mapObject.getPoints());
+			if ((isClosed(mapObject))) {
 				pen.closePath();
 				pen.fill();
 			} else pen.stroke();
@@ -77,7 +77,7 @@ public class MapCanvas {
 	}
 
 	//HOT FIX UNTIL MapObject isOpen() IS WORKING
-	private boolean isClosed(MapObject object) {
-		return object.getOsmType() != OSMType.ROAD && (object.getOsmType() != OSMType.HIGHWAY && (object.getOsmType() != OSMType.COASTLINE));
+	private boolean isClosed(MapObject mapObject) {
+		return mapObject.getOsmType() != OSMType.ROAD && (mapObject.getOsmType() != OSMType.HIGHWAY && (mapObject.getOsmType() != OSMType.COASTLINE));
 	}
 }

--- a/src/main/java/com/noticemedan/map/viewmodel/MapCanvas.java
+++ b/src/main/java/com/noticemedan/map/viewmodel/MapCanvas.java
@@ -12,6 +12,7 @@ import javafx.scene.canvas.Canvas;
 import javafx.scene.canvas.GraphicsContext;
 import javafx.scene.paint.Color;
 import lombok.Getter;
+import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 
 import java.awt.*;
@@ -21,127 +22,67 @@ import java.util.Map;
 @Slf4j
 public class MapCanvas {
 
-    @Getter private Canvas canvas;
-    private MapObjectCreater mapObjectCreater;
-    private Map<OSMType,List<MapObject>> mapObjects;
-    private GraphicsContext pen;
+	@Getter private Canvas canvas;
+	private GraphicsContext pen;
+	private ForestCreator forestCreator;
+	private Forest forest;
+	@Getter @Setter
+	private double zoomLevel;
+	@Getter @Setter
+	private Rect viewArea;
 
-    public MapCanvas(Dimension dim) {
-        super();
-		this.canvas = new Canvas(50, 50);
+	public MapCanvas() {
+		this.canvas = new Canvas(6000, 6000);
 		this.pen = canvas.getGraphicsContext2D();
-		this.mapObjectCreater = MapObjectCreater.getInstance(dim);
-		this.mapObjects = mapObjectCreater.getMapObjectsByType();
-
-		//@Magnus sådan kommer du til at bruge forest klassen med et eksempel på range search.
-		//Brug evt. debugger for at inspicere mapObjects:)
-		ForestCreator forestCreator = new ForestCreator();
-		Forest forest = forestCreator.getForest();
-		List<MapObject> mapObjects = forest.rangeSearch(new Rect(20,20,500,500));
-
-        drawCanvas();
-    }
-
-    private void drawCanvas() {
-    	/*setPenAttributes(3, Color.ORANGE);
-		if (mapContainsKey(OSMType.COASTLINE))
-			drawObjects(mapObjects.get(OSMType.COASTLINE));
-
-		 setPenAttributes(0.2, Color.rgb(250, 75, 255, 0.2));
-		if (mapContainsKey(OSMType.UNKNOWN))
-			drawObjects(mapObjects.get(OSMType.UNKNOWN));*/
-
-        setPenAttributes(5,Color.LIGHTGRAY);
-        if (mapContainsKey(OSMType.ROAD))
-        	drawObjects(mapObjects.get(OSMType.ROAD));
-
-        setPenAttributes(10.0,Color.ORANGE);
-        if (mapContainsKey(OSMType.HIGHWAY))
-        	drawObjects(mapObjects.get(OSMType.HIGHWAY));
-
-        setPenAttributes(0.2,Color.rgb(125, 125,125));
-        if (mapContainsKey(OSMType.BUILDING))
-        	drawObjects(mapObjects.get(OSMType.BUILDING));
-
-		setPenAttributes(0.2,Color.rgb(12,158,89));
-		if (mapContainsKey(OSMType.GRASSLAND))
-			drawObjects(mapObjects.get(OSMType.GRASSLAND));
-
-		setPenAttributes(0.2, Color.rgb(40,84,210));
-		if (mapContainsKey(OSMType.WATER))
-			drawObjects(mapObjects.get(OSMType.WATER));
-
-		setPenAttributes(0.2,Color.YELLOW);
-		if (mapContainsKey(OSMType.SAND))
-			drawObjects(mapObjects.get(OSMType.SAND));
-
-		setPenAttributes(0.2,Color.rgb(12,158,89));
-		if (mapContainsKey(OSMType.TREE_ROW))
-			drawObjects(mapObjects.get(OSMType.TREE_ROW));
-
-		setPenAttributes(0.2,Color.rgb(73,150,128));
-		if (mapContainsKey(OSMType.HEATH))
-			drawObjects(mapObjects.get(OSMType.HEATH));
-
-		setPenAttributes(0.2,Color.rgb(88,232,93));
-		if (mapContainsKey(OSMType.PLAYGROUND))
-			drawObjects(mapObjects.get(OSMType.PLAYGROUND));
-
-		setPenAttributes(0.2,Color.rgb(14,184,118));
-		if (mapContainsKey(OSMType.GARDEN))
-			drawObjects(mapObjects.get(OSMType.GARDEN));
-
-		setPenAttributes(0.2,Color.rgb(14,184,118));
-		if (mapContainsKey(OSMType.PARK))
-			drawObjects(mapObjects.get(OSMType.PARK));
-    }
-
-    private boolean mapContainsKey(OSMType key) {
-    	return mapObjects.containsKey(key);
+		this.forestCreator = new ForestCreator();
+		this.forest = forestCreator.getForest();
+		this.zoomLevel = 1.0;
+		this.viewArea = new Rect(0,0,2000,2000);
+		drawCanvas();
 	}
 
-    private void setPenAttributes(double lineWidth, Color color){
-    	pen.setLineWidth(lineWidth);
-    	pen.setStroke(color);
-    	pen.setFill(color);
+	private void drawCanvas() {
+		pen.setStroke(Color.WHITE);
+		pen.setFill(Color.WHITE);
+		pen.setLineWidth(2);
+		drawObjects(forest.rangeSearch(viewArea));
+	}
+
+	public void redrawCanvas(){
+		pen.clearRect(0,0,canvas.getWidth(),canvas.getHeight());
+		drawCanvas();
 	}
 
 	private void drawObjects(List<MapObject> objects){
-    	for(MapObject object : objects){
-    		List<Point2D> points = object.getPoints();
-    		drawPath(points);
+		for(MapObject object : objects){
+			if(object.getOsmType()==OSMType.UNKNOWN) continue;
+			if(object.getColor()!=null) setPenColor(object.getColor()); //IF-STATEMENT UNTIL MapObject getColor() WORKS PROPERLY
+
+			drawPath(object.getPoints());
 			if ((isClosed(object))) {
 				pen.closePath();
 				pen.fill();
 			} else pen.stroke();
 		}
-    }
+	}
 
 	private void drawPath(List<Point2D> points) {
 		Point2D startPoint = points.get(0);
 		pen.beginPath();
-		pen.moveTo(startPoint.getX(), startPoint.getY());
+		pen.moveTo(startPoint.getX()*this.zoomLevel, startPoint.getY()*this.zoomLevel);
 		for (int i = 1; i < points.size(); i++) {
 			Point2D nextPoint = points.get(i);
-			putOnCanvas(nextPoint);
-			pen.lineTo(nextPoint.getX(), nextPoint.getY());
+			pen.lineTo(nextPoint.getX()*this.zoomLevel, nextPoint.getY()*this.zoomLevel);
 		}
 	}
 
+	private void setPenColor(Color color){
+		pen.setStroke(color);
+		pen.setFill(color);
+	}
+
+	//HOT FIX UNTIL MapObject isOpen() IS WORKING
 	private boolean isClosed(MapObject object) {
 		return object.getOsmType() != OSMType.ROAD && (object.getOsmType() != OSMType.HIGHWAY && (object.getOsmType() != OSMType.COASTLINE));
 	}
-
-	private void putOnCanvas(Point2D point) {
-		if(point.getX()>canvas.getWidth()) resizeCanvasWidth(point.getX());
-		if(point.getY()>canvas.getHeight()) resizeCanvasHeight(point.getY());
-	}
-
-    private void resizeCanvasWidth(double width){
-        this.canvas.setWidth(width);
-    }
-
-    private void resizeCanvasHeight(double height){
-        this.canvas.setHeight(height);
-    }
 }

--- a/src/main/java/com/noticemedan/map/viewmodel/MapCanvas.java
+++ b/src/main/java/com/noticemedan/map/viewmodel/MapCanvas.java
@@ -77,6 +77,7 @@ public class MapCanvas {
 	}
 
 	//HOT FIX UNTIL MapObject isOpen() IS WORKING
+	//TODO set boolean isOpen() when creating new MapObject.
 	private boolean isClosed(MapObject mapObject) {
 		return mapObject.getOsmType() != OSMType.ROAD && (mapObject.getOsmType() != OSMType.HIGHWAY && (mapObject.getOsmType() != OSMType.COASTLINE));
 	}

--- a/src/main/java/com/noticemedan/map/viewmodel/MouseController.java
+++ b/src/main/java/com/noticemedan/map/viewmodel/MouseController.java
@@ -14,6 +14,7 @@ public class MouseController {
 	 * TODO Make zoomMethod: that take use of the zoomLevel variable in MapCanvas.
 	 * TODO Make zoomMethod: that scales properly without messing with the KD-TREE search area.
 	 * */
+	//OLD ZOOM
     public void addZoomAbility(CustomPane customPane){
         customPane.getCanvasContent().setOnScroll(event -> {
             event.consume();
@@ -27,22 +28,22 @@ public class MouseController {
     }
 
 	//STILL BUGGY - Don't always draw on last position, and a bit laggy.
-	public void dragAndDraw(CustomPane customPane){
-		customPane.setOnDragDetected(event -> {
-			event.consume();
+	public void dragAndDraw(CustomPane customPane) {
+	customPane.setOnDragDetected(event -> {
+		//multiply with 0.5/1.5 to increase the rangesearch search area
+		double minX = Math.abs(customPane.getViewportBounds().getMinX());
+		double minY = Math.abs(customPane.getViewportBounds().getMinY());
 
-			//multiply with 0.5/1.5 to increase the rangesearch search area
-            double minX = Math.abs(customPane.getViewportBounds().getMinX()) * 0.5;
-            double minY = Math.abs(customPane.getViewportBounds().getMinY()) * 0.5;
+		double maxX = minX + customPane.getViewportBounds().getWidth();
+		double maxY = minY + customPane.getViewportBounds().getHeight();
 
-            double maxX = minX + customPane.getViewportBounds().getWidth() * 1.5;
-            double maxY = minY + customPane.getViewportBounds().getHeight() * 1.5;
+		Rect viewPort = new Rect(minX * 0.5,minY * 0.5,maxX * 1.5,maxY * 1.5);
+		log.info("3  " + viewPort);
 
-			Rect viewPort = new Rect(minX,minY,maxX,maxY);
-			log.info("3  " + viewPort);
-
-			customPane.getMapCanvas().setViewArea(viewPort);
-			customPane.getMapCanvas().redrawCanvas();
-		});
+		customPane.getMapCanvas().setViewArea(viewPort);
+		customPane.getMapCanvas().redrawCanvas();
+		event.consume();
+	});
 	}
 }
+

--- a/src/main/java/com/noticemedan/map/viewmodel/MouseController.java
+++ b/src/main/java/com/noticemedan/map/viewmodel/MouseController.java
@@ -1,7 +1,9 @@
 package com.noticemedan.map.viewmodel;
 
 import com.noticemedan.map.model.KDTree.Rect;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 public class MouseController {
 
     private final double factor = 1.1;
@@ -18,28 +20,22 @@ public class MouseController {
         });
     }
 
-    public void panning(CustomPane customPane){
-    	customPane.setOnDragDetected(event -> {
-			/*System.out.println("Scrollbar: "+ customPane.getHvalue() + " | " + customPane.getVvalue());
-			System.out.println("Layout: "+ customPane.getLayoutX() + " | " + customPane.getLayoutY());
-			System.out.println("Viewport Bounds: " + customPane.getViewportBounds());*/
-		});
-	}
-
 	//TESTING
-	public void panDraw(CustomPane customPane){
-		customPane.setOnDragDetected(event -> customPane.setOnMouseReleased(event2 -> {
-            double minX = Math.abs(customPane.getViewportBounds().getMinX());
-            double minY = Math.abs(customPane.getViewportBounds().getMinY());
+	public void dragAndDraw(CustomPane customPane){
+		customPane.setOnDragDetected(event -> {
+			event.consume();
 
-            double maxX = minX + customPane.getViewportBounds().getWidth();
-            double maxY = minY + customPane.getViewportBounds().getHeight();
-            Rect viewPort = new Rect(minX,minY,maxX*2,maxY*2);
+            double minX = Math.abs(customPane.getViewportBounds().getMinX()) * 0.5;
+            double minY = Math.abs(customPane.getViewportBounds().getMinY()) * 0.5;
 
-			System.out.println(customPane.getViewportBounds().getWidth() + " , " + customPane.getViewportBounds().getHeight() + " | " + customPane.getViewportBounds().getMinX() + " , " + customPane.getViewportBounds().getMinY());
-            System.out.println("3  " + viewPort);
-            customPane.getMapCanvas().setViewArea(viewPort);
-            customPane.getMapCanvas().redrawCanvas();
-			}));
+            double maxX = minX + customPane.getViewportBounds().getWidth() * 1.5;
+            double maxY = minY + customPane.getViewportBounds().getHeight() * 1.5;
+
+			Rect viewPort = new Rect(minX,minY,maxX,maxY);
+			log.info("3  " + viewPort);
+
+			customPane.getMapCanvas().setViewArea(viewPort);
+			customPane.getMapCanvas().redrawCanvas();
+		});
 	}
 }

--- a/src/main/java/com/noticemedan/map/viewmodel/MouseController.java
+++ b/src/main/java/com/noticemedan/map/viewmodel/MouseController.java
@@ -32,11 +32,14 @@ public class MouseController {
             double minX = Math.abs(customPane.getViewportBounds().getMinX());
             double minY = Math.abs(customPane.getViewportBounds().getMinY());
 
-            double maxX = minX + customPane.getViewportBounds().getMaxX();
-            double maxY = minY + customPane.getViewportBounds().getMaxY();
-            Rect viewPort = new Rect(minX,minY,maxX,maxY);
+            double maxX = minX + customPane.getViewportBounds().getWidth();
+            double maxY = minY + customPane.getViewportBounds().getHeight();
+            Rect viewPort = new Rect(minX,minY,maxX*2,maxY*2);
+
+			System.out.println(customPane.getViewportBounds().getWidth() + " , " + customPane.getViewportBounds().getHeight() + " | " + customPane.getViewportBounds().getMinX() + " , " + customPane.getViewportBounds().getMinY());
             System.out.println("3  " + viewPort);
             customPane.getMapCanvas().setViewArea(viewPort);
-            customPane.getMapCanvas().redrawCanvas();}));
+            customPane.getMapCanvas().redrawCanvas();
+			}));
 	}
 }

--- a/src/main/java/com/noticemedan/map/viewmodel/MouseController.java
+++ b/src/main/java/com/noticemedan/map/viewmodel/MouseController.java
@@ -21,28 +21,22 @@ public class MouseController {
 
             if (event.getDeltaY() == 0) return;
 
-            double scaleFactor = (event.getDeltaY() > 0) ? factor : 1 / factor;
+            double zoomLevel = customPane.getMapCanvas().getZoomLevel();
+            zoomLevel = (event.getDeltaY() > 0) ? zoomLevel * 1.1 : zoomLevel * (1 / 1.1);
 
-            customPane.zoomToCenter(scaleFactor);
+            customPane.getMapCanvas().setZoomLevel(zoomLevel);
+            customPane.getMapCanvas().redrawCanvas();
         });
     }
 
 	//STILL BUGGY - Don't always draw on last position, and a bit laggy.
 	public void dragAndDraw(CustomPane customPane) {
 	customPane.setOnDragDetected(event -> {
-		//multiply with 0.5/1.5 to increase the rangesearch search area
-		double minX = Math.abs(customPane.getViewportBounds().getMinX());
-		double minY = Math.abs(customPane.getViewportBounds().getMinY());
-
-		double maxX = minX + customPane.getViewportBounds().getWidth();
-		double maxY = minY + customPane.getViewportBounds().getHeight();
-
-		Rect viewPort = new Rect(minX * 0.5,minY * 0.5,maxX * 1.5,maxY * 1.5);
+		event.consume();
+		Rect viewPort = customPane.getExtendedViewPortBounds();
 		log.info("3  " + viewPort);
-
 		customPane.getMapCanvas().setViewArea(viewPort);
 		customPane.getMapCanvas().redrawCanvas();
-		event.consume();
 	});
 	}
 }

--- a/src/main/java/com/noticemedan/map/viewmodel/MouseController.java
+++ b/src/main/java/com/noticemedan/map/viewmodel/MouseController.java
@@ -1,5 +1,7 @@
 package com.noticemedan.map.viewmodel;
 
+import com.noticemedan.map.model.KDTree.Rect;
+
 public class MouseController {
 
     private final double factor = 1.1;
@@ -15,4 +17,26 @@ public class MouseController {
             customPane.zoomToCenter(scaleFactor);
         });
     }
+
+    public void panning(CustomPane customPane){
+    	customPane.setOnDragDetected(event -> {
+			/*System.out.println("Scrollbar: "+ customPane.getHvalue() + " | " + customPane.getVvalue());
+			System.out.println("Layout: "+ customPane.getLayoutX() + " | " + customPane.getLayoutY());
+			System.out.println("Viewport Bounds: " + customPane.getViewportBounds());*/
+		});
+	}
+
+	//TESTING
+	public void panDraw(CustomPane customPane){
+		customPane.setOnDragDetected(event -> customPane.setOnMouseReleased(event2 -> {
+            double minX = Math.abs(customPane.getViewportBounds().getMinX());
+            double minY = Math.abs(customPane.getViewportBounds().getMinY());
+
+            double maxX = minX + customPane.getViewportBounds().getMaxX();
+            double maxY = minY + customPane.getViewportBounds().getMaxY();
+            Rect viewPort = new Rect(minX,minY,maxX,maxY);
+            System.out.println("3  " + viewPort);
+            customPane.getMapCanvas().setViewArea(viewPort);
+            customPane.getMapCanvas().redrawCanvas();}));
+	}
 }

--- a/src/main/java/com/noticemedan/map/viewmodel/MouseController.java
+++ b/src/main/java/com/noticemedan/map/viewmodel/MouseController.java
@@ -8,32 +8,29 @@ public class MouseController {
 
     private double zoomLevel = 1.0;
 
-	/*
-	THIS NEEDS TO BE REDONE TO WORK WITH KD-TREE AND zoomLevel in MapCanvas
+	/*THIS NEEDS TO BE REDONE TO WORK WITH KD-TREE AND zoomLevel in MapCanvas
 	TODO Make zoomMethod: that pivots around mouseposition.
 	TODO Make zoomMethod: that take use of the zoomLevel variable in MapCanvas.
-	TODO Make zoomMethod: that scales properly without messing with the KD-TREE search area.
-	*/
+	TODO Make zoomMethod: that scales properly without messing with the KD-TREE search area.*/
 	public void addZoomAbility(CustomPane customPane) {
-        customPane.getCanvasContent().setOnScroll(event -> {
-            event.consume();
+		customPane.getCanvasContent().setOnScroll(event -> {
+			event.consume();
 
-            if (event.getDeltaY() == 0) return;
+			if (event.getDeltaY() == 0) return;
 
-            this.zoomLevel = customPane.getMapCanvas().getZoomLevel();
-            this.zoomLevel = (event.getDeltaY() > 0) ? zoomLevel * 1.1 : zoomLevel * (1 / 1.1);
+			double oldZoomLevel = customPane.getMapCanvas().getZoomLevel();
+			this.zoomLevel = (event.getDeltaY() > 0) ? oldZoomLevel * 1.1 : oldZoomLevel * (1 / 1.1);
 
-            customPane.getMapCanvas().setZoomLevel(zoomLevel);
-            customPane.getMapCanvas().redrawCanvas();
-        });
-    }
+			customPane.getMapCanvas().setZoomLevel(this.zoomLevel);
+			customPane.getMapCanvas().redrawCanvas();
+		});
+	}
 
-	//STILL BUGGY - Don't always draw on last position, and a bit laggy.
+	// TODO FIX INITIAL LAG
 	public void dragAndDraw(CustomPane customPane) {
 	customPane.setOnDragDetected(event -> {
 		event.consume();
-		Rect viewPort = customPane.getExtendedViewPortBounds();
-		log.info("3  " + viewPort);
+		Rect viewPort = customPane.getExtendedViewPortBounds(this.zoomLevel);
 		customPane.getMapCanvas().setViewArea(viewPort);
 		customPane.getMapCanvas().redrawCanvas();
 	});

--- a/src/main/java/com/noticemedan/map/viewmodel/MouseController.java
+++ b/src/main/java/com/noticemedan/map/viewmodel/MouseController.java
@@ -8,6 +8,12 @@ public class MouseController {
 
     private final double factor = 1.1;
 
+    //THIS NEEDS TO BE REDONE TO WORK WITH KD-TREE AND zoomLevel in MapCanvas
+	/**
+	 * TODO Make zoomMethod: that pivots around mouseposition.
+	 * TODO Make zoomMethod: that take use of the zoomLevel variable in MapCanvas.
+	 * TODO Make zoomMethod: that scales properly without messing with the KD-TREE search area.
+	 * */
     public void addZoomAbility(CustomPane customPane){
         customPane.getCanvasContent().setOnScroll(event -> {
             event.consume();
@@ -20,11 +26,12 @@ public class MouseController {
         });
     }
 
-	//TESTING
+	//STILL BUGGY - Don't always draw on last position, and a bit laggy.
 	public void dragAndDraw(CustomPane customPane){
 		customPane.setOnDragDetected(event -> {
 			event.consume();
 
+			//multiply with 0.5/1.5 to increase the rangesearch search area
             double minX = Math.abs(customPane.getViewportBounds().getMinX()) * 0.5;
             double minY = Math.abs(customPane.getViewportBounds().getMinY()) * 0.5;
 

--- a/src/main/java/com/noticemedan/map/viewmodel/MouseController.java
+++ b/src/main/java/com/noticemedan/map/viewmodel/MouseController.java
@@ -6,23 +6,22 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class MouseController {
 
-    private final double factor = 1.1;
+    private double zoomLevel = 1.0;
 
-    //THIS NEEDS TO BE REDONE TO WORK WITH KD-TREE AND zoomLevel in MapCanvas
-	/**
-	 * TODO Make zoomMethod: that pivots around mouseposition.
-	 * TODO Make zoomMethod: that take use of the zoomLevel variable in MapCanvas.
-	 * TODO Make zoomMethod: that scales properly without messing with the KD-TREE search area.
-	 * */
-	//OLD ZOOM
-    public void addZoomAbility(CustomPane customPane){
+	/*
+	THIS NEEDS TO BE REDONE TO WORK WITH KD-TREE AND zoomLevel in MapCanvas
+	TODO Make zoomMethod: that pivots around mouseposition.
+	TODO Make zoomMethod: that take use of the zoomLevel variable in MapCanvas.
+	TODO Make zoomMethod: that scales properly without messing with the KD-TREE search area.
+	*/
+	public void addZoomAbility(CustomPane customPane) {
         customPane.getCanvasContent().setOnScroll(event -> {
             event.consume();
 
             if (event.getDeltaY() == 0) return;
 
-            double zoomLevel = customPane.getMapCanvas().getZoomLevel();
-            zoomLevel = (event.getDeltaY() > 0) ? zoomLevel * 1.1 : zoomLevel * (1 / 1.1);
+            this.zoomLevel = customPane.getMapCanvas().getZoomLevel();
+            this.zoomLevel = (event.getDeltaY() > 0) ? zoomLevel * 1.1 : zoomLevel * (1 / 1.1);
 
             customPane.getMapCanvas().setZoomLevel(zoomLevel);
             customPane.getMapCanvas().redrawCanvas();


### PR DESCRIPTION
Denne feature gør at kortet tegnes fra kd-tree.

Kortet kan nu tegnes fra KD-træet, og der kan navigeres rundt i view og tegnes afhængigt af hvor viewet er ift. canvas. Navigation er stadig lidt buggy, og zoom er disabled indtil en ny methode er lavet. Farverne ser mærkelige pga. en fejl i mapObject, hvilket Simon er i fuld gang med at fixe.

Jeg har ikke brugt vavr, da det kræver flere ændringer i model (MapObject, KD-Tree osv.) før det kan bruges i viewmodel.